### PR TITLE
add support for new 'uORF' type

### DIFF
--- a/ng/src/org/gmod/schema/feature/UORF.java
+++ b/ng/src/org/gmod/schema/feature/UORF.java
@@ -1,0 +1,37 @@
+package org.gmod.schema.feature;
+
+import org.gmod.schema.cfg.FeatureType;
+import org.gmod.schema.mapped.Organism;
+
+import org.hibernate.search.annotations.Indexed;
+
+import java.sql.Timestamp;
+
+import javax.persistence.Entity;
+import javax.persistence.Transient;
+
+@Entity
+@FeatureType(cv = "sequence", term = "uORF")
+@Indexed
+public class UORF extends NcRNA {
+
+    UORF() {
+        // empty
+    }
+
+    public UORF(Organism organism, String uniqueName, boolean analysis, boolean obsolete,
+            Timestamp dateAccessioned) {
+        super(organism, uniqueName, analysis, obsolete, dateAccessioned);
+    }
+    UORF(Organism organism, String uniqueName, String name) {
+        this(organism, uniqueName, false, false, new Timestamp(System.currentTimeMillis()));
+        setName(name);
+    }
+
+    @Override
+    @Transient
+    public Integer getColourId() {
+        return null;
+    }
+
+}


### PR DESCRIPTION
These features are not supposed to be treated like coding proteins for now,
as discussed with Fatima and Sufen. Hence they are added as a subclass
of NcRNA.