### PR TITLE
also push database releases to vm-pg-path-genedb

### DIFF
--- a/ng/scripts/indexing/index.sh
+++ b/ng/scripts/indexing/index.sh
@@ -541,6 +541,9 @@ if [[ $COPY_NIGHTLY_TO_STAGING ]]; then
       logecho "Problem running fix-snapshot (exitCode: $exitCode)"
       cat fix-snapshot.log
     fi
+
+    # Also run new release code, pushing to a staging on a managed cluster
+    /nfs/users/nfs_p/pathdb/switch_dbs.sh
 fi
 
 #


### PR DESCRIPTION
This PR adds a call to a script which takes care of pushing processed Chado contents into the new managed DBs. This is a temporary approach to verify that this works in an automated fashion, once this is confirmed the code will be integrated here.