### PR TITLE
fix loading of EuPathDB converted EMBL files

### DIFF
--- a/ng/src/org/genedb/db/loading/FeatureTable.java
+++ b/ng/src/org/genedb/db/loading/FeatureTable.java
@@ -282,7 +282,7 @@ class FeatureTable extends EmblFile.Section {
         public boolean isPseudo() {
             return hasQualifier("pseudo");
         }
-        
+
         /**
          * Is this feature obsolete?
          *
@@ -396,7 +396,7 @@ class FeatureTable extends EmblFile.Section {
 
     private static final String symbolPattern = "[\\w'*-+]*[A-Za-z][\\w'*-+]*";
     static final Pattern qualifierPattern = Pattern.compile("/(" + symbolPattern + ")(?:=(.*))?");
-    static final Pattern quotedStringPattern = Pattern.compile("\"((?:[^\"]|\"\")*)\"");
+    static final Pattern quotedStringPattern = Pattern.compile("\"([^\"]*)\"");
 
     private String currentQualifier = null;
     private StringBuilder currentString = null;
@@ -412,7 +412,7 @@ class FeatureTable extends EmblFile.Section {
                 // This is the last line of the string
                 if (! data.endsWith("\"")) {
                     throw new SyntaxError("Failed to parse string data: unbalanced quotes");
-                    
+
                 }
                 currentString.append(data.substring(0, data.length() - 1).replaceAll("\"\"", "\""));
                 currentFeature.qualifiers.add(new Qualifier(currentQualifier, currentString.toString(), true));


### PR DESCRIPTION
When trying to use the EMBL loader on EuPathDB converted EMBL files, the regex got into a stack overflow error due to excessive matching of one of the subgroups. This PR simplifies the pattern to include any string between two double quotes. Can anyone comment on why the original pattern was crafted in this way?