### PR TITLE
remove news item

### DIFF
--- a/ng/WebContent/WEB-INF/jsp/homepages/frontPage.jsp
+++ b/ng/WebContent/WEB-INF/jsp/homepages/frontPage.jsp
@@ -110,7 +110,6 @@ Application deadline: <b>17 June 2016</b>
 <div class="light-grey">
 <p class="block-para">
 &raquo; The results of the 2013 TriTrypDB user survey are ready (April 2014). Thanks to all participants for their useful input and suggestions. A detailed <a href="http://tritrypdb.org/tritrypdb/communityDownload.do?fname=2013_TriTryp_User_Survey_Results.pdf">summary</a> is available for your review.<br>
-&raquo; We would like some feedback from the community on gene family nomenclature in <i>Plasmodium</i> genomes! Please take a look at our <a href="http://www.genedb.org/artemis/Gene_family_nomenclature_proposal.pdf">gene family nomenclature proposal</a> and <a href="mailto:genedb-help@sanger.ac.uk">let us know</a> if you have any comments.<br>
 </p>
 </div>
 <div class="light-grey-bot"></div>


### PR DESCRIPTION
This PR removes the news item on the _Plasmodium_ nomenclature call for community feedback.